### PR TITLE
On bootstrap, don't assume the app is online

### DIFF
--- a/src/online-listener.js
+++ b/src/online-listener.js
@@ -9,7 +9,7 @@ const onlineSubject$ = new ReplaySubject(1)
 const online$ = onlineSubject$.asObservable()
 let urlToHit
 
-onlineSubject$.next(true)
+onlineSubject$.next(navigator.onLine)
 
 function updateOnlineStatus (evt) {
   if (navigator && navigator.onLine != undefined) {


### PR DESCRIPTION
This is useful for when the app is still loading due to offline service worker cache